### PR TITLE
WIP: Enhance coverage script

### DIFF
--- a/get_coverage_for_challenge.sh
+++ b/get_coverage_for_challenge.sh
@@ -58,9 +58,11 @@ insertVbcTag "${SCRIPT_CURRENT_DIR}/src/BeFaster.App.Tests/BeFaster.App.Tests.vb
 [ -e ${SCRIPT_CURRENT_DIR}/__UnitTestWithAltCover ] && rm -fr ${SCRIPT_CURRENT_DIR}/__UnitTestWithAltCover
 
 # Instrument the binaries so that coverage can be collected
+FULL_PATH_TO_ALTCOVER="$(cd ${SCRIPT_CURRENT_DIR} && find . -path *altcover* | head -n 1 || true)"/tools/net45/AltCover.exe
+
 (
     cd ${SCRIPT_CURRENT_DIR} && \
-    mono ${SCRIPT_CURRENT_DIR}/packages/altcover.3.5.569/tools/net45/AltCover.exe \
+    mono ${SCRIPT_CURRENT_DIR}/${FULL_PATH_TO_ALTCOVER}                           \
       --opencover --linecover                                                     \
       --inputDirectory ${SCRIPT_CURRENT_DIR}/src/BeFaster.App.Tests/bin/Debug     \
       --assemblyFilter=Adapter                                                    \
@@ -74,7 +76,7 @@ insertVbcTag "${SCRIPT_CURRENT_DIR}/src/BeFaster.App.Tests/BeFaster.App.Tests.vb
       --assemblyExcludeFilter=Mono\.DllMap.+                                      \
       --typeFilter=System.                                                        \
       --outputDirectory=${SCRIPT_CURRENT_DIR}/__UnitTestWithAltCover              \
-      --xmlReport=${VBNET_INSTRUMENTED_COVERAGE_REPORT} || true
+      --xmlReport=${VBNET_INSTRUMENTED_COVERAGE_REPORT}
 )
 
 # Run the tests against the instrumented binaries
@@ -82,12 +84,12 @@ FULL_PATH_TO_NUNIT_CONSOLE="$(cd ${SCRIPT_CURRENT_DIR} && find . -path *nunit*co
 
 (
   cd ${SCRIPT_CURRENT_DIR} && \
-    mono ${SCRIPT_CURRENT_DIR}/packages/altcover.3.5.569/tools/net45/AltCover.exe Runner                \
-        --executable ${SCRIPT_CURRENT_DIR}/${FULL_PATH_TO_NUNIT_CONSOLE}                                \
-        --recorderDirectory ${SCRIPT_CURRENT_DIR}/__UnitTestWithAltCover/                               \
-        -w ${SCRIPT_CURRENT_DIR}                                                                        \
-        -- --noheader --labels=All  --work=${SCRIPT_CURRENT_DIR}                                        \
-        --result=${VBNET_TEST_RUN_REPORT}                                                               \
+    mono ${SCRIPT_CURRENT_DIR}/${FULL_PATH_TO_ALTCOVER} Runner                \
+        --executable ${SCRIPT_CURRENT_DIR}/${FULL_PATH_TO_NUNIT_CONSOLE}      \
+        --recorderDirectory ${SCRIPT_CURRENT_DIR}/__UnitTestWithAltCover/     \
+        -w ${SCRIPT_CURRENT_DIR}                                              \
+        -- --noheader --labels=All  --work=${SCRIPT_CURRENT_DIR}              \
+        --result=${VBNET_TEST_RUN_REPORT}                                     \
         ${SCRIPT_CURRENT_DIR}/__UnitTestWithAltCover/BeFaster.App.Tests.dll || true
 )
 


### PR DESCRIPTION
Catch failing coverage gathering step, also capture the correct full path to AltCover installed, in the absence of it results in the script failing


Fixes https://github.com/julianghionoiu/tdl-lord-of-runners/issues/15

The absence of the dependencies needed to run the coverage step successfully results in the program failing, which should alter AWS that script could not be executed successfully due to some user change to the coverage step.

Potentially a change made to the build configuration could have resulted in it. 